### PR TITLE
fix: correctly size grouped chart with dynamic facet

### DIFF
--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -416,8 +416,10 @@ function getOffsetRange(channel: string, model: UnitModel, offsetScaleType: Scal
 
   if (positionScaleType === 'band') {
     const size = getDiscretePositionSize(positionChannel, model.size, model.config.view);
+    const sizeChannel = positionChannel === X ? 'width' : 'height';
+    const facetParent = getFacetModel(model);
 
-    if (isStep(size)) {
+    if (isStep(size) && !facetParent?.hasExplicitSize(sizeChannel)) {
       // step is for offset
       const step = getOffsetStep(size, offsetScaleType);
       if (step) {


### PR DESCRIPTION
Fixes https://github.com/exploreomni/omni/issues/30484

When there's an xOffset encoding present, a default `{ step: 20 }` was being set as the xOffset scale. This lets it fallback on  the `bandwidth` for the x encoding for the xOffset range maximum.

Here's a demonstration of the fix on my instance (same setup as the bug):
https://crossfit.rahb.sandbox.exploreomni.dev/e/1:zCTTlVSZ/1